### PR TITLE
Restart vault service if package has been changed (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `service_options`: Extra argument to pass to `vault server`, as per: `vault server --help`
 
+* `restart_service`: Restart service if the package has been changed.
+
 * `num_procs`: Sets the `GOMAXPROCS` environment variable, to determine how many CPUs Vault can use. The official Vault Terraform install.sh script sets this to the output of ``nprocs``, with the comment, "Make sure to use all our CPUs, because Vault can block a scheduler thread". Default: number of CPUs on the system, retrieved from the ``processorcount`` fact.
 
 * `manage_backend_dir`: When using the file backend, this boolean determines whether or not the path (as specified in the `['file']['path']` section of the backend config) is created, and the owner and group set to the vault user.  Default: `false`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@
 # * `manage_service`
 #   Instruct puppet to manage service or not
 #
+# * `restart_service`
+#   Instruct puppet to restart service if the package has been changed
+#
 # * `num_procs`
 #   Sets the GOMAXPROCS environment variable, to determine how many CPUs Vault
 #   can use. The official Vault Terraform install.sh script sets this to the
@@ -76,6 +79,7 @@ class vault (
   $service_provider    = $::vault::params::service_provider,
   $manage_service      = $::vault::params::manage_service,
   $manage_service_file = $::vault::params::manage_service_file,
+  $restart_service     = $::vault::restart_service,
   $backend             = $::vault::params::backend,
   $manage_backend_dir  = $::vault::params::manage_backend_dir,
   $listener            = $::vault::params::listener,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,8 +23,15 @@ class vault::install {
       }
 
     'repo': {
-      package { $::vault::package_name:
-        ensure  => $::vault::package_ensure,
+      if $::vault::restart_service and $::vault::manage_service  {
+        package { $::vault::package_name:
+          ensure => $::vault::package_ensure,
+          notify => Service['vault'],
+        }
+      } else {
+        package { $::vault::package_name:
+          ensure => $::vault::package_ensure,
+        }
       }
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class vault::params {
   $download_extension = 'zip'
   $version            = '0.8.0'
   $service_name       = 'vault'
+  $restart_service    = false
   $num_procs          = $::processorcount
   $install_method     = 'archive'
   $package_name       = 'vault'

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -134,6 +134,21 @@ describe 'vault' do
 
           it { should contain_package('vault') }
         end
+
+        context "installs from repository with restart_service enabled" do
+          let(:params) {{
+            :install_method  => 'repo',
+            :package_name    => 'vault',
+            :manage_service  => true,
+            :restart_service => true,
+            :package_ensure  => 'installed',
+          }}
+
+          it {
+            should contain_package('vault')
+              .that_notifies('Service[vault]')
+          }
+        end
       end
 
       context "when specifying manage_service" do


### PR DESCRIPTION
New parameter restart_service added with default value false.
When restart_service is set to true, vault service will be restarted
if the package has been changed. This is useful when we want to upgrade
vault  without manual intervention in our testing environments.